### PR TITLE
Push to history instead of redirect to new paste

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import SubmitButton from '../components/SubmitButton';
 import Loading from '../components/Loading';
 import Alert from '../components/Alert';
-import { Redirect, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import FullContainer from '../components/FullContainer';
 import usePostPaste from '../hooks/usePostPaste';
 import RandomButton from '../components/RandomButton';
@@ -35,21 +35,19 @@ function Home({ onPaste }) {
   const [password, setPassword] = React.useState('');
   const [oneTimeView, setOneTimeView] = React.useState(false);
   const [isEmbeddable, setIsEmbeddable] = React.useState(true);
+  const history = useHistory();
 
   React.useEffect(() => {
     if (pasteId) {
       onPaste(pasteId);
+      history.push(`/${pasteId}`);
     }
   }, [pasteId]);
-
-  const history = useHistory();
 
   async function handleRandomClick() {
     const paste = await getRandomPaste();
     history.push(`/${paste._id}`);
   }
-
-  if (pasteId) return <Redirect to={`/${pasteId}`} />;
 
   return (
     <FullContainer>


### PR DESCRIPTION
With this fix, you can go back to the home page after a paste is created.
The go-back button of your browser wouldn't work before this change because a redirect overrides the history.