### PR TITLE
Use children instead of component property

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -29,17 +29,15 @@ function App() {
         </Confirmation>
       )}
       <Router>
-        <Route exact path="/" component={() => <Home onPaste={onPaste} />} />
-        <Route
-          exact
-          path="/:pasteId"
-          component={(props) => <Paste {...props} />}
-        />
-        <Route
-          exact
-          path="/embed/:pasteId"
-          component={(props) => <Paste embedded {...props} />}
-        />
+        <Route exact path="/">
+          <Home onPaste={onPaste} />
+        </Route>
+        <Route exact path="/:pasteId">
+          <Paste />
+        </Route>
+        <Route exact path="/embed/:pasteId">
+          <Paste embedded />
+        </Route>
       </Router>
     </div>
   );

--- a/client/src/pages/Paste.js
+++ b/client/src/pages/Paste.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import PasteBody from '../components/PasteBody';
 import WarningButton from '../components/WarningButton';
 import useDeletePaste from '../hooks/useDeletePaste';
+import { useParams } from 'react-router-dom';
 
 const Content = styled.div`
   overflow: auto;
@@ -17,8 +18,8 @@ const Content = styled.div`
   align-items: center;
 `;
 
-function Paste({ match, embedded }) {
-  const { pasteId } = match.params;
+function Paste({ embedded }) {
+  const { pasteId } = useParams();
   const [{ paste, error, loading }, doGet] = useGetPaste(pasteId);
   const [oneTimeActive, doDelete] = useDeletePaste(pasteId);
 

--- a/client/src/pages/Paste.js
+++ b/client/src/pages/Paste.js
@@ -66,7 +66,6 @@ function Paste({ embedded }) {
 }
 
 Paste.propTypes = {
-  match: PropTypes.object,
   embedded: PropTypes.bool,
 };
 


### PR DESCRIPTION
See https://reacttraining.com/react-router/web/api/Route/component
> When you use component (instead of render or children, below) the router uses React.createElement to create a new React element from the given component. That means if you provide an inline function to the component prop, you would create a new component every render. This results in the existing component unmounting and the new component mounting instead of just updating the existing component. When using an inline function for inline rendering, use the render or the children prop (below).