### PR TITLE
Adjust full container height to support small devices

### DIFF
--- a/client/src/components/FullContainer.js
+++ b/client/src/components/FullContainer.js
@@ -5,8 +5,8 @@ const FullContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 100vw;
-  height: 100vh;
+  min-height: 100vh;
+  padding: 20px;
 `;
 
 export default FullContainer;


### PR DESCRIPTION
The fixed height was the reason that the logo was too small on mobile